### PR TITLE
Added postinstall script to symlink - resolves #10

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Linting SCSS for consistency - and victory!",
   "main": ".scss-lint.yml",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "postinstall": "ln -s .scss-lint ../../.scss-lint"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Do you guys think it needs to be any smarter than this?

Its assuming that npm is installing without any custom config so all libs are in `node_modules/lib`. Thought about adding an echo statement to remind people to add `.scss-lint` to their `.gitignore` as well.

Thoughts?